### PR TITLE
fixing two json issues in a template.json file

### DIFF
--- a/src/content/Company.RageMpClientResource/.template.config/template.json
+++ b/src/content/Company.RageMpClientResource/.template.config/template.json
@@ -1,8 +1,7 @@
 {
     "$schema": "http://json.schemastore.org/template",
     "author": "Dave Horsefield",
-    "description" : "This template creates a RAGE-MP client resource defaulted to netcoreapp2.1. 
-    	It doesn't get built to dll but rather a housing for CSharp files to be built into RAGEMP client packages. (Specify a name with -n)",
+    "description" : "This template creates a RAGE-MP client resource defaulted to netcoreapp2.1. It doesn't get built to dll but rather a housing for CSharp files to be built into RAGEMP client packages. (Specify a name with -n)",
     "classifications": [ "RageMp", "Client" ],
     "groupIdentity": "RageMpClientResource",
     "identity": "RageMpClientResource",        
@@ -29,8 +28,7 @@
         "type": "project"
         },    
     "sourceName": "Company.RageMpClientResource",
-    "preferNameDirectory": true    
-        },    
+    "preferNameDirectory": true,    
     "primaryOutputs": [
         {
           "path": "Company.RageMpClientResource.csproj"


### PR DESCRIPTION
I noticed a couple of errors in one of the `template.json` files. I changed the following.

 - Made `description` into a single line instead of spanning across multiple lines
 - Removed an extra `}`